### PR TITLE
Fix: cycle chat history

### DIFF
--- a/ElvUI/modules/chat/chat.lua
+++ b/ElvUI/modules/chat/chat.lua
@@ -348,7 +348,7 @@ function CH:StyleChat(frame)
 	end
 
 	--Work around broken SetAltArrowKeyMode API. Code from Prat
-	local function OnKeyDown(editBox, key)
+	local function OnArrowPressed(editBox, key)
 		if (not editBox.historyLines) or #editBox.historyLines == 0 then return end
 
 		if key == "DOWN" then
@@ -385,7 +385,7 @@ function CH:StyleChat(frame)
 	--Work around broken SetAltArrowKeyMode API
 	editbox.historyLines = ElvCharacterDB.ChatEditHistory
 	editbox.historyIndex = 0
-	editbox:HookScript("OnKeyDown", OnKeyDown)
+	editbox:HookScript("OnArrowPressed", OnArrowPressed)
 	editbox:Hide()
 
 	editbox:HookScript("OnEditFocusGained", function(editBox)

--- a/ElvUI/modules/chat/chat.lua
+++ b/ElvUI/modules/chat/chat.lua
@@ -349,7 +349,7 @@ function CH:StyleChat(frame)
 
 	--Work around broken SetAltArrowKeyMode API. Code from Prat
 	local function OnArrowPressed(editBox, key)
-		if (not editBox.historyLines) or #editBox.historyLines == 0 then return end
+		if (not editBox.historyLines) or #editBox.historyLines == 0 or CH.db.useAltKey then return end
 
 		if key == "DOWN" then
 			editBox.historyIndex = editBox.historyIndex - 1
@@ -377,7 +377,7 @@ function CH:StyleChat(frame)
 	_G[format(editbox:GetName().."FocusMid", id)]:Kill()
 	_G[format(editbox:GetName().."FocusRight", id)]:Kill()
 	editbox:SetTemplate("Default", true)
-	editbox:SetAltArrowKeyMode(CH.db.useAltKey)
+	editbox:SetAltArrowKeyMode(nil)
 	editbox:SetAllPoints(LeftChatDataPanel)
 	self:SecureHook(editbox, "AddHistoryLine", "ChatEdit_AddHistory")
 	editbox:HookScript("OnTextChanged", OnTextChanged)
@@ -469,15 +469,6 @@ function CH:AddMessage(msg, infoR, infoG, infoB, infoID, accessID, typeID, isHis
 	end
 
 	self.OldAddMessage(self, msg, infoR, infoG, infoB, infoID, accessID, typeID)
-end
-
-function CH:UpdateSettings()
-	for i = 1, CreatedFrames do
-		local chat = _G[format("ChatFrame%d", i)]
-		local name = chat:GetName()
-		local editbox = _G[name.."EditBox"]
-		editbox:SetAltArrowKeyMode(CH.db.useAltKey)
-	end
 end
 
 local removeIconFromLine

--- a/ElvUI_Config/chat.lua
+++ b/ElvUI_Config/chat.lua
@@ -136,7 +136,6 @@ E.Options.args.chat = {
 					desc = L["Require holding the Alt key down to move cursor or cycle through messages in the editbox."],
 					set = function(self, value)
 						E.db.chat.useAltKey = value
-						CH:UpdateSettings()
 					end
 				},
 				autoClosePetBattleLog = {


### PR DESCRIPTION
#### What does this PR do?
Changes the `OnKeyDown` method for chat history cycling to `OnArrowPressed`.
Debugging showed that `OnKeyDown` never actually fires.

#### What are the relevant tickets?
fix #44 