### PR TITLE
Fix shadow orb bar

### DIFF
--- a/ElvUI/Libraries/oUF/elements/classpower.lua
+++ b/ElvUI/Libraries/oUF/elements/classpower.lua
@@ -152,7 +152,6 @@ do
 		ClassPowerID = SPELL_POWER_SHADOW_ORBS
 		ClassPowerType = 'SHADOW_ORBS'
 		RequireSpec = SPEC_PRIEST_SHADOW
-		RequireSpell = 95740 -- Shadow Orbs
 	end
 end
 


### PR DESCRIPTION
This pr fixes #49

The spell requirement for shadow orbs isn't necessary, due to having a spec check in place.
If you would have a loading screen, without having any shadow orbs, the `RequireSpell`-check would fail, resulting in the bar disappearing.