### PR TITLE
[Fix] ignore ELVUI_VERSIONCHK from retail (5.0 or higher) versions

### DIFF
--- a/ElvUI/ElvUI.toc
+++ b/ElvUI/ElvUI.toc
@@ -1,6 +1,6 @@
 ﻿## Interface: 50400
 ## Author: Elv, Bunny, Apollyon
-## Version: 1.23
+## Version: 1.24
 ## Title: |cff00dd91E|r|cffe5e3e3lvUI|r
 ## Notes: User Interface replacement AddOn for World of Warcraft.
 ## SavedVariables: ElvDB, ElvPrivateDB

--- a/ElvUI/core/core.lua
+++ b/ElvUI/core/core.lua
@@ -886,6 +886,7 @@ local function SendRecieve(_, event, prefix, message, _, sender)
 
 		if prefix == "ELVUI_VERSIONCHK" then
 			local msg, ver = tonumber(message), tonumber(E.version)
+			if msg and (msg > 5) then return end -- ignore retail versions
 			if msg and (msg > ver) then -- you're outdated D:
 				if not E.recievedOutOfDateMessage then
 					E:Print(L["ElvUI is out of date. You can download the newest version from https://github.com/ElvUI-MoP"])


### PR DESCRIPTION
People who use the legacy retail version of ElvUI make us fail the versioncheck upon grouping.

Since there are still retail versions around, we should ignore any version >^5.*

freakz.ro for example hosts a proprietary version for their client.